### PR TITLE
broaden generic bounds on tree methods

### DIFF
--- a/Homework3.md
+++ b/Homework3.md
@@ -1,4 +1,3 @@
-
 In this third assignment, we are starting with a solution for hw2, with some minor additional changes, including 
 setting the server to single-threaded by default. We'll return to studying multi-threaded server performance later. 
 
@@ -9,13 +8,97 @@ behavior of the program, and the sources of performance degradation.
 
 Unfortunately, while the hw3 code is much better than the hw2 code, addressing synchronization issues and efficient batch processing, there remains a significant performance problem. 
 
-To see the problem, start the server using only the ``--addr`` and ``--exit-code`` parameters. Then,
-run the benchmark program using the above parameters as well as ``--threads 1``. Then, run the same 
+To see the problem, start the server using only the ``--addr`` and ``--exit-code`` parameters.
+
+Benchmark raw:
+        --- Benchmark Results ---
+        Total Operations: 10000
+        Total Duration:   42.5727 s
+        Avg Operations/s: 234.89
+        Throughput:       0.0002 M req/s
+
+        Executed in   38.59 secs    fish           external
+           usr time    1.04 secs  591.00 micros    1.04 secs  35%
+           sys time    1.89 secs  358.00 micros    1.89 secs  65%
+
+Benchmark 1 thread:
+        --- Benchmark Results ---
+        Total Operations: 1000
+        Total Duration:   1.7980 s
+        Avg Operations/s: 556.16
+        Throughput:       0.0006 M req/s
+
+        Executed in    2.33 secs      fish           external
+           usr time   19.99 millis  474.00 micros   19.52 millis 18%
+           sys time   91.37 millis  284.00 micros   91.09 millis 82%
+
+Benchmark 2 thread:
+        --- Benchmark Results ---
+        Total Operations: 2000
+        Total Duration:   4.0348 s
+        Avg Operations/s: 495.68
+        Throughput:       0.0005 M req/s
+
+        Executed in    4.47 secs      fish           external
+           usr time   68.83 millis  435.00 micros   68.39 millis 23%
+           sys time  229.88 millis  262.00 micros  229.61 millis 77%
+
+
+Benchmark 3 thread:
+        --- Benchmark Results ---
+        Total Operations: 3000
+        Total Duration:   6.8261 s
+        Avg Operations/s: 439.49
+        Throughput:       0.0004 M req/s
+
+        Executed in    7.28 secs      fish           external
+           usr time  198.20 millis  789.00 micros  197.41 millis 35%
+           sys time  369.08 millis    0.00 micros  369.08 millis 65%
+
+
+
+Then, run the benchmark program using the above parameters as well as ``--threads 1``. Then, run the same 
 experiment, but now with ``--threads 2``, and ``--threads 4``. The more client threads we add, the lower the measured performance. 
+
+    % time     seconds  usecs/call     calls    errors syscall
+    ------ ----------- ----------- --------- --------- ------------------
+     74.01   26.790909        5343      5014           close
+     20.54    7.434208        1494      4974           openat
+      3.24    1.171650       55792        21           accept4
+      2.17    0.785436         157      4973           write
+      0.03    0.011302          62       180           recvfrom
+      0.01    0.003610          35       101           sendto
+      0.00    0.000706         705         1           execve
+      0.00    0.000457          14        32           brk
+      0.00    0.000448          29        15           munmap
+      0.00    0.000306          11        26           mmap
+      0.00    0.000198           9        22           setsockopt
+      0.00    0.000180           8        21           fcntl
+      0.00    0.000086          14         6           mprotect
+      0.00    0.000071          14         5           read
+      0.00    0.000048           9         5           rt_sigaction
+      0.00    0.000044          10         4           newfstatat
+      0.00    0.000040           9         4           pread64
+      0.00    0.000027           8         3           sigaltstack
+      0.00    0.000023          11         2         1 arch_prctl
+      0.00    0.000023          22         1           socket
+      0.00    0.000020          10         2           prlimit64
+      0.00    0.000016          15         1         1 access
+      0.00    0.000014          13         1           bind
+      0.00    0.000013          12         1           poll
+      0.00    0.000011          11         1           getrandom
+      0.00    0.000010          10         1           listen
+      0.00    0.000010          10         1           sched_getaffinity
+      0.00    0.000010           9         1           getpid
+      0.00    0.000010           9         1           rseq
+      0.00    0.000009           9         1           set_robust_list
+      0.00    0.000009           9         1           set_tid_address
+    ------ ----------- ----------- --------- --------- ------------------
+    100.00   36.199902        2347     15422         2 total
 
 _Without_ doing a line by line comparison of the source code (including _not_ using git diff and such), use profiling tools to get further clues as to why the server is now so absurdly slow. 
 
-- [ ] Does ``time`` give you any useful clues? Is it spending more time waiting, working in user space, or in the kernel? How does this proportion change with the number of client threads?
+- [x] Does ``time`` give you any useful clues? Is it spending more time waiting, working in user space, or in the kernel? How does this proportion change with the number of client threads?
 - [ ] Based on what ``time`` told you, you'll want to again either use ``perf record`` or ``strace`` to see what we were waiting for. 
 - [ ] Try running the server with ``--dbfile /tmp/$USER.db`` where ``$USER`` is your username. Think of ``/tmp/`` as very fast storage for now. Storing the database there makes server substantially faster, but if you increase to ``--ops 10000``, you'll find that the thread slowdown trend persists even with ``/tmp/`` storage. 
 - [ ] Note: A lesser version of the problem even occurs with ``-m`` (mem-only database), but let's focus on the storage-based version for now. 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -4,6 +4,7 @@
 // serde = { version = "1.0", features = ["derive"] }
 // bincode = "1.3"
 
+use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::fs::File;
 use std::io::{self, Read, Write};
@@ -24,6 +25,7 @@ struct Node<K: Ord + Clone, V: Clone> {
     left: Option<Box<Node<K, V>>>,
     right: Option<Box<Node<K, V>>>,
 }
+
 impl<K: Ord + Clone + Serialize + DeserializeOwned, V: Clone + Serialize + DeserializeOwned> TreeMap<K, V> {
     pub fn new() -> Self { TreeMap { root: None } }
 
@@ -45,10 +47,20 @@ impl<K: Ord + Clone + Serialize + DeserializeOwned, V: Clone + Serialize + Deser
         }
     }
 
-    pub fn get(&self, key: &K) -> Option<V> { Self::get_node(&self.root, key) }
-    fn get_node(node: &Option<Box<Node<K, V>>>, key: &K) -> Option<V> {
+    pub fn get<Q>(&self, key: &Q) -> Option<V> 
+    where 
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    { 
+        Self::get_node(&self.root, key)
+    }
+    fn get_node<Q>(node: &Option<Box<Node<K, V>>>, key: &Q) -> Option<V> 
+    where 
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
         match node {
-            Some(n) => match key.cmp(&n.key) {
+            Some(n) => match key.cmp(n.key.borrow()) {
                 Ordering::Less    => Self::get_node(&n.left, key),
                 Ordering::Greater => Self::get_node(&n.right, key),
                 Ordering::Equal   => Some(n.value.clone()),
@@ -57,10 +69,20 @@ impl<K: Ord + Clone + Serialize + DeserializeOwned, V: Clone + Serialize + Deser
         }
     }
 
-    pub fn remove(&mut self, key: &K) -> Option<V> { Self::remove_node(&mut self.root, key) }
-    fn remove_node(node: &mut Option<Box<Node<K, V>>>, key: &K) -> Option<V> {
+    pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
+    where 
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    { 
+        Self::remove_node(&mut self.root, key) 
+    }
+    fn remove_node<Q>(node: &mut Option<Box<Node<K, V>>>, key: &Q) -> Option<V> 
+    where 
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
         if let Some(n) = node {
-            match key.cmp(&n.key) {
+            match key.cmp(n.key.borrow()) {
                 Ordering::Less    => return Self::remove_node(&mut n.left, key),
                 Ordering::Greater => return Self::remove_node(&mut n.right, key),
                 Ordering::Equal   => {
@@ -97,11 +119,15 @@ impl<K: Ord + Clone + Serialize + DeserializeOwned, V: Clone + Serialize + Deser
         node
     }
 
-    pub fn seek_ge(&self, key: &K) -> Option<(K, V)> {
+    pub fn seek_ge<Q>(&self, key: &Q) -> Option<(K, V)>
+    where 
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
         let mut res = None;
         let mut cur = &self.root;
         while let Some(n) = cur {
-            if &n.key < key { cur = &n.right; }
+            if n.key.borrow() < key { cur = &n.right; }
             else { res = Some((n.key.clone(), n.value.clone())); cur = &n.left; }
         }
         res


### PR DESCRIPTION
introduce generic for `get`, `remove` and `seek_ge` on tree allowing any borrowed form of the key type.